### PR TITLE
Fix label sync workflow

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -11,13 +11,8 @@ jobs:
       issues: write
 
     steps:
-      - name: Checkout basher83/docs repository
+      - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          repository: basher83/docs
-          path: central-docs
-          # Uncomment if private:
-          # token: ${{ secrets.DOCS_REPO_PAT }}
 
       - name: Install yq v4
         run: |
@@ -28,43 +23,20 @@ jobs:
         run: yq --version
 
       - name: Transform labels
-        id: transform
         run: |
           echo "Working directory:"
           pwd
           echo "Checking if source file exists:"
-          ls -la central-docs/mission-control/github-configs/label-definitions.yml
+          ls -la label-definitions.yml
           echo "First few lines of source file:"
-          head -20 central-docs/mission-control/github-configs/label-definitions.yml
+          head -20 label-definitions.yml
           echo "Transforming labels..."
-          yq eval '[.[] | .[]]' central-docs/mission-control/github-configs/label-definitions.yml > transformed-labels.yml
+          yq eval '[.[] | .[]]' label-definitions.yml > transformed-labels.yml
           echo "Checking if transformed file was created:"
           ls -la transformed-labels.yml
           echo "First few lines of transformed file:"
           head -20 transformed-labels.yml
-          echo "Setting output variable with relative path:"
-          echo "manifest_path=transformed-labels.yml" >> "$GITHUB_OUTPUT"
-          echo "Verifying output was set"
-          echo "Contents of GITHUB_OUTPUT:"
-          cat "$GITHUB_OUTPUT" || echo "GITHUB_OUTPUT file not found"
 
-      - name: Debug outputs
-        run: |
-          echo "Checking step outputs:"
-          echo "transform step outputs: ${{ toJson(steps.transform.outputs) }}"
-          echo "manifest_path value: '${{ steps.transform.outputs.manifest_path }}'"
-          echo "Current working directory:"
-          pwd
-          echo "Files in current directory:"
-          ls -la
-          echo "Checking transformed-labels.yml:"
-          if [ -f "transformed-labels.yml" ]; then
-            echo "File exists! Size: $(wc -l < transformed-labels.yml) lines"
-            echo "First 10 lines:"
-            head -10 transformed-labels.yml
-          else
-            echo "File does not exist!"
-          fi
 
       - name: Sync labels to this repository
         uses: micnncim/action-label-syncer@v1.3.0


### PR DESCRIPTION
## Summary
- make workflow fetch labels from repository
- simplify transform step

## Testing
- `yamllint .github/workflows/sync-labels.yml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68475ca326588333b06114ce1042f09c